### PR TITLE
Implement claude-plan-tracker CLI tool

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-plan-tracker hook session-start"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-plan-tracker hook session-end"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-plan-tracker hook post-tool-use"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+
+# Test coverage
+coverage/
+
+# Environment
+.env
+.env.local
+
+# Claude Code local settings (not shared)
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -96,12 +96,32 @@ commits:
 ## Roadmap
 
 - [x] Project setup and documentation
-- [ ] Basic plan persistence (SessionEnd hook)
-- [ ] Commit tracking (PostToolUse hook)
-- [ ] Branch-aware context loading (SessionStart hook)
-- [ ] CLI commands (init, status, list, sync)
+- [x] Basic plan persistence (SessionEnd hook)
+- [x] Commit tracking (PostToolUse hook)
+- [x] Branch-aware context loading (SessionStart hook)
+- [x] CLI commands (init, status, list, sync)
 - [ ] Plan diff viewer
 - [ ] PR description generation from plans
+
+## Development
+
+```bash
+# Clone the repo
+git clone https://github.com/JanSmrcka/claude-plan-tracker.git
+cd claude-plan-tracker
+
+# Install dependencies
+npm install
+
+# Build
+npm run build
+
+# Run locally
+node dist/index.js --help
+
+# Or use tsx for development
+npm run dev -- --help
+```
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,59 @@ claude-plan-tracker init
 claude
 ```
 
+## Local Installation (from source)
+
+If you want to test locally before the package is published to npm:
+
+### Option 1: npm link
+
+```bash
+# Clone and build
+git clone https://github.com/JanSmrcka/claude-plan-tracker.git
+cd claude-plan-tracker
+npm install
+npm run build
+
+# Link globally
+npm link
+
+# Now use in any project
+cd /path/to/your/project
+claude-plan-tracker init
+```
+
+### Option 2: Direct path in hooks config
+
+Create `.claude/settings.json` in your project with absolute paths:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "node /path/to/claude-plan-tracker/dist/index.js hook session-start"
+      }]
+    }],
+    "SessionEnd": [{
+      "hooks": [{
+        "type": "command",
+        "command": "node /path/to/claude-plan-tracker/dist/index.js hook session-end"
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{
+        "type": "command",
+        "command": "node /path/to/claude-plan-tracker/dist/index.js hook post-tool-use"
+      }]
+    }]
+  }
+}
+```
+
+Replace `/path/to/claude-plan-tracker` with the actual path where you cloned the repo.
+
 ## Commands
 
 | Command | Description |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,597 @@
+{
+  "name": "claude-plan-tracker",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-plan-tracker",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "claude-plan-tracker": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
+      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "claude-plan-tracker",
+  "version": "0.1.0",
+  "description": "CLI tool to persist Claude Code plans and track commits across git branches",
+  "type": "module",
+  "main": "./dist/index.js",
+  "bin": {
+    "claude-plan-tracker": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.ts",
+    "test": "node --test --experimental-strip-types src/**/*.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "claude",
+    "claude-code",
+    "ai",
+    "developer-tools",
+    "git",
+    "planning"
+  ],
+  "author": "Jan Smrcka",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JanSmrcka/claude-plan-tracker.git"
+  },
+  "bugs": {
+    "url": "https://github.com/JanSmrcka/claude-plan-tracker/issues"
+  },
+  "homepage": "https://github.com/JanSmrcka/claude-plan-tracker#readme",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,79 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type { ClaudeSettings, HookMatcher } from '../lib/types.js';
+
+const HOOKS_CONFIG: Record<string, HookMatcher[]> = {
+  SessionStart: [
+    {
+      hooks: [
+        {
+          type: 'command',
+          command: 'npx claude-plan-tracker hook session-start',
+        },
+      ],
+    },
+  ],
+  SessionEnd: [
+    {
+      hooks: [
+        {
+          type: 'command',
+          command: 'npx claude-plan-tracker hook session-end',
+        },
+      ],
+    },
+  ],
+  PostToolUse: [
+    {
+      matcher: 'Bash',
+      hooks: [
+        {
+          type: 'command',
+          command: 'npx claude-plan-tracker hook post-tool-use',
+        },
+      ],
+    },
+  ],
+};
+
+export async function initCommand(): Promise<void> {
+  const cwd = process.cwd();
+  const claudeDir = path.join(cwd, '.claude');
+  const settingsPath = path.join(claudeDir, 'settings.json');
+  const plansDir = path.join(claudeDir, 'plans');
+
+  // Create .claude directory if it doesn't exist
+  await fs.mkdir(claudeDir, { recursive: true });
+  await fs.mkdir(plansDir, { recursive: true });
+
+  // Load existing settings or create new
+  let settings: ClaudeSettings = {};
+  try {
+    const existing = await fs.readFile(settingsPath, 'utf-8');
+    settings = JSON.parse(existing);
+  } catch {
+    // File doesn't exist, start fresh
+  }
+
+  // Merge hooks configuration
+  settings.hooks = {
+    ...settings.hooks,
+    ...HOOKS_CONFIG,
+  };
+
+  // Write settings
+  await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+
+  console.log('Claude Plan Tracker initialized successfully!');
+  console.log('');
+  console.log('Created:');
+  console.log(`  ${settingsPath}`);
+  console.log(`  ${plansDir}/`);
+  console.log('');
+  console.log('Hooks configured:');
+  console.log('  - SessionStart: Load previous plan context');
+  console.log('  - SessionEnd: Persist plan to repo');
+  console.log('  - PostToolUse: Track git commits');
+  console.log('');
+  console.log('Start a new Claude Code session to begin tracking plans.');
+}

--- a/src/cli/list.ts
+++ b/src/cli/list.ts
@@ -1,0 +1,55 @@
+import { getRepoRoot } from '../lib/git-utils.js';
+import { listTrackedPlans } from '../lib/plan-store.js';
+
+export async function listCommand(): Promise<void> {
+  const cwd = process.cwd();
+
+  let repoRoot: string;
+  try {
+    repoRoot = await getRepoRoot(cwd);
+  } catch {
+    console.log('Not in a git repository.');
+    return;
+  }
+
+  const plans = await listTrackedPlans(repoRoot);
+
+  if (plans.length === 0) {
+    console.log('No tracked plans found.');
+    console.log('');
+    console.log('Run "claude-plan-tracker init" to set up plan tracking.');
+    return;
+  }
+
+  console.log('Tracked Plans:');
+  console.log('');
+
+  // Header
+  const cols = {
+    branch: 20,
+    source: 25,
+    updated: 20,
+    commits: 8,
+  };
+
+  const header = [
+    'Branch'.padEnd(cols.branch),
+    'Source'.padEnd(cols.source),
+    'Last Updated'.padEnd(cols.updated),
+    'Commits'.padEnd(cols.commits),
+  ].join(' | ');
+
+  console.log(header);
+  console.log('-'.repeat(header.length));
+
+  for (const plan of plans) {
+    const row = [
+      plan.metadata.branch.slice(0, cols.branch).padEnd(cols.branch),
+      plan.metadata.source.slice(0, cols.source).padEnd(cols.source),
+      plan.metadata.last_updated.slice(0, cols.updated).padEnd(cols.updated),
+      String(plan.metadata.commits.length).padEnd(cols.commits),
+    ].join(' | ');
+
+    console.log(row);
+  }
+}

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,0 +1,51 @@
+import { getCurrentBranch, getRepoRoot } from '../lib/git-utils.js';
+import { findLatestPlanForBranch, loadPlanContent } from '../lib/claude-storage.js';
+import { loadPlan } from '../lib/plan-store.js';
+
+export async function statusCommand(): Promise<void> {
+  const cwd = process.cwd();
+
+  // Get git info
+  let branch: string;
+  let repoRoot: string;
+  try {
+    branch = await getCurrentBranch(cwd);
+    repoRoot = await getRepoRoot(cwd);
+  } catch {
+    console.log('Not in a git repository.');
+    return;
+  }
+
+  console.log(`Branch: ${branch}`);
+  console.log('');
+
+  // Check repo plan
+  const repoPlan = await loadPlan(repoRoot, branch);
+  if (repoPlan) {
+    console.log('Repo Plan:');
+    console.log(`  Source: ${repoPlan.metadata.source}`);
+    console.log(`  Last Updated: ${repoPlan.metadata.last_updated}`);
+    console.log(`  Commits: ${repoPlan.metadata.commits.length} tracked`);
+    if (repoPlan.metadata.commits.length > 0) {
+      console.log(`    ${repoPlan.metadata.commits.slice(0, 5).join(', ')}${repoPlan.metadata.commits.length > 5 ? '...' : ''}`);
+    }
+    console.log('');
+  } else {
+    console.log('Repo Plan: None');
+    console.log('');
+  }
+
+  // Check Claude storage
+  const claudeSlug = await findLatestPlanForBranch(cwd, branch);
+  if (claudeSlug) {
+    const claudePlan = await loadPlanContent(claudeSlug);
+    console.log('Claude Storage:');
+    console.log(`  Latest Plan: ${claudeSlug}.md`);
+    if (claudePlan) {
+      const preview = claudePlan.slice(0, 200).replace(/\n/g, ' ');
+      console.log(`  Preview: ${preview}${claudePlan.length > 200 ? '...' : ''}`);
+    }
+  } else {
+    console.log('Claude Storage: No plan found for this branch');
+  }
+}

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -1,0 +1,60 @@
+import { getCurrentBranch, getRepoRoot } from '../lib/git-utils.js';
+import { findLatestPlanForBranch, loadPlanContent } from '../lib/claude-storage.js';
+import { savePlan, loadPlan } from '../lib/plan-store.js';
+
+interface SyncFlags {
+  force?: boolean;
+  all?: boolean;
+  [key: string]: string | boolean | undefined;
+}
+
+export async function syncCommand(flags: SyncFlags): Promise<void> {
+  const cwd = process.cwd();
+
+  let branch: string;
+  let repoRoot: string;
+  try {
+    branch = await getCurrentBranch(cwd);
+    repoRoot = await getRepoRoot(cwd);
+  } catch {
+    console.log('Not in a git repository.');
+    return;
+  }
+
+  console.log(`Syncing plan for branch: ${branch}`);
+
+  // Find latest plan from Claude storage
+  const slug = await findLatestPlanForBranch(cwd, branch);
+  if (!slug) {
+    console.log('No plan found in Claude storage for this branch.');
+    return;
+  }
+
+  const content = await loadPlanContent(slug);
+  if (!content) {
+    console.log(`Could not load plan content: ${slug}.md`);
+    return;
+  }
+
+  // Check existing repo plan
+  const existingPlan = await loadPlan(repoRoot, branch);
+  if (existingPlan && !flags.force) {
+    const existingDate = new Date(existingPlan.metadata.last_updated);
+    const now = new Date();
+    if (now.getTime() - existingDate.getTime() < 60000) {
+      console.log('Repo plan was updated less than a minute ago. Use --force to override.');
+      return;
+    }
+  }
+
+  // Save to repo
+  await savePlan(repoRoot, branch, content, {
+    branch,
+    source: `${slug}.md`,
+    last_updated: new Date().toISOString(),
+    commits: existingPlan?.metadata.commits || [],
+  });
+
+  console.log(`Plan synced to .claude/plans/`);
+  console.log(`  Source: ${slug}.md`);
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,20 @@
+import { sessionStartHook } from './session-start.js';
+import { sessionEndHook } from './session-end.js';
+import { postToolUseHook } from './post-tool-use.js';
+
+export async function runHook(hookName: string): Promise<void> {
+  switch (hookName) {
+    case 'session-start':
+      await sessionStartHook();
+      break;
+    case 'session-end':
+      await sessionEndHook();
+      break;
+    case 'post-tool-use':
+      await postToolUseHook();
+      break;
+    default:
+      console.error(`Unknown hook: ${hookName}`);
+      process.exit(1);
+  }
+}

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -1,0 +1,76 @@
+import type { PostToolUseInput } from '../lib/types.js';
+import { getCurrentBranch, getRepoRoot, getLatestCommit } from '../lib/git-utils.js';
+import { addCommitToPlan } from '../lib/plan-store.js';
+
+export async function postToolUseHook(): Promise<void> {
+  // Read input from stdin
+  const stdin = await readStdin();
+  if (!stdin) {
+    process.exit(0);
+    return;
+  }
+
+  let input: PostToolUseInput;
+  try {
+    input = JSON.parse(stdin);
+  } catch {
+    process.exit(0);
+    return;
+  }
+
+  const { cwd, tool_name, tool_input } = input;
+
+  // Only process Bash commands
+  if (tool_name !== 'Bash') {
+    process.exit(0);
+    return;
+  }
+
+  // Check if this was a git commit
+  const command = (tool_input as { command?: string }).command || '';
+  if (!isGitCommit(command)) {
+    process.exit(0);
+    return;
+  }
+
+  // Get branch and repo info
+  const branch = await getCurrentBranch(cwd).catch(() => null);
+  const repoRoot = await getRepoRoot(cwd).catch(() => null);
+
+  if (!branch || !repoRoot) {
+    process.exit(0);
+    return;
+  }
+
+  // Get the latest commit hash
+  const commitHash = await getLatestCommit(cwd);
+  if (!commitHash) {
+    process.exit(0);
+    return;
+  }
+
+  // Add commit to plan tracking
+  await addCommitToPlan(repoRoot, branch, commitHash.slice(0, 7));
+
+  process.exit(0);
+}
+
+function isGitCommit(command: string): boolean {
+  const commitPatterns = [
+    /git\s+commit/,
+    /git\s+merge\s+--no-ff/,
+  ];
+  return commitPatterns.some(pattern => pattern.test(command));
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk: string) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(''));
+
+    setTimeout(() => resolve(data), 1000);
+  });
+}

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -1,0 +1,71 @@
+import type { SessionEndInput } from '../lib/types.js';
+import { getCurrentBranch, getRepoRoot } from '../lib/git-utils.js';
+import { findLatestPlanForBranch, loadPlanContent } from '../lib/claude-storage.js';
+import { savePlan, loadPlan } from '../lib/plan-store.js';
+
+export async function sessionEndHook(): Promise<void> {
+  // Read input from stdin
+  const stdin = await readStdin();
+  if (!stdin) {
+    process.exit(0);
+    return;
+  }
+
+  let input: SessionEndInput;
+  try {
+    input = JSON.parse(stdin);
+  } catch {
+    process.exit(0);
+    return;
+  }
+
+  const { cwd } = input;
+
+  // Get current branch and repo root
+  const branch = await getCurrentBranch(cwd).catch(() => null);
+  const repoRoot = await getRepoRoot(cwd).catch(() => null);
+
+  if (!branch || !repoRoot) {
+    process.exit(0);
+    return;
+  }
+
+  // Find latest plan from Claude storage
+  const slug = await findLatestPlanForBranch(cwd, branch);
+  if (!slug) {
+    process.exit(0);
+    return;
+  }
+
+  const content = await loadPlanContent(slug);
+  if (!content) {
+    process.exit(0);
+    return;
+  }
+
+  // Load existing plan to preserve commits
+  const existingPlan = await loadPlan(repoRoot, branch);
+  const commits = existingPlan?.metadata.commits || [];
+
+  // Save plan to repo
+  await savePlan(repoRoot, branch, content, {
+    branch,
+    source: `${slug}.md`,
+    last_updated: new Date().toISOString(),
+    commits,
+  });
+
+  process.exit(0);
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk: string) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(''));
+
+    setTimeout(() => resolve(data), 1000);
+  });
+}

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,0 +1,88 @@
+import type { SessionStartInput, HookOutput } from '../lib/types.js';
+import { getCurrentBranch, getRepoRoot } from '../lib/git-utils.js';
+import { findLatestPlanForBranch, loadPlanContent } from '../lib/claude-storage.js';
+import { loadPlan } from '../lib/plan-store.js';
+
+export async function sessionStartHook(): Promise<void> {
+  // Read input from stdin
+  const stdin = await readStdin();
+  if (!stdin) {
+    process.exit(0);
+  }
+
+  let input: SessionStartInput;
+  try {
+    input = JSON.parse(stdin);
+  } catch {
+    process.exit(0);
+    return; // TypeScript flow control
+  }
+
+  const { cwd } = input;
+
+  // Get current branch
+  const branch = await getCurrentBranch(cwd).catch(() => null);
+  const repoRoot = await getRepoRoot(cwd).catch(() => null);
+
+  if (!branch || !repoRoot) {
+    process.exit(0);
+    return;
+  }
+
+  // Build context from previous plans
+  const contextParts: string[] = [];
+
+  // Check repo plan first
+  const repoPlan = await loadPlan(repoRoot, branch);
+  if (repoPlan) {
+    contextParts.push(`## Previous Plan for branch "${branch}"`);
+    contextParts.push('');
+    contextParts.push(repoPlan.content);
+
+    if (repoPlan.metadata.commits.length > 0) {
+      contextParts.push('');
+      contextParts.push('### Commits from previous sessions:');
+      for (const commit of repoPlan.metadata.commits.slice(0, 10)) {
+        contextParts.push(`- ${commit}`);
+      }
+    }
+  } else {
+    // Try Claude storage
+    const slug = await findLatestPlanForBranch(cwd, branch);
+    if (slug) {
+      const content = await loadPlanContent(slug);
+      if (content) {
+        contextParts.push(`## Previous Plan for branch "${branch}"`);
+        contextParts.push(`(Source: ${slug}.md)`);
+        contextParts.push('');
+        contextParts.push(content);
+      }
+    }
+  }
+
+  // Output context if we found anything
+  if (contextParts.length > 0) {
+    const output: HookOutput = {
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: contextParts.join('\n'),
+      },
+    };
+    console.log(JSON.stringify(output));
+  }
+
+  process.exit(0);
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk: string) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(''));
+
+    // Timeout after 1 second
+    setTimeout(() => resolve(data), 1000);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import { parseArgs } from './utils/args.js';
+import { initCommand } from './cli/init.js';
+import { statusCommand } from './cli/status.js';
+import { listCommand } from './cli/list.js';
+import { syncCommand } from './cli/sync.js';
+import { runHook } from './hooks/index.js';
+
+const VERSION = '0.1.0';
+
+const HELP = `
+claude-plan-tracker - Persist Claude Code plans across sessions
+
+Usage:
+  claude-plan-tracker <command> [options]
+
+Commands:
+  init          Setup hooks in .claude/settings.json
+  status        Show plan status for current branch
+  list          List all tracked branches and plans
+  sync          Manually sync current plan to repo
+  hook <name>   Run a hook (used internally by Claude Code)
+
+Options:
+  --help, -h    Show this help message
+  --version     Show version number
+
+Examples:
+  claude-plan-tracker init
+  claude-plan-tracker status
+  claude-plan-tracker list
+`;
+
+async function main(): Promise<void> {
+  const { command, args, flags } = parseArgs(process.argv.slice(2));
+
+  if (flags.help || flags.h) {
+    console.log(HELP);
+    process.exit(0);
+  }
+
+  if (flags.version) {
+    console.log(VERSION);
+    process.exit(0);
+  }
+
+  try {
+    switch (command) {
+      case 'init':
+        await initCommand();
+        break;
+      case 'status':
+        await statusCommand();
+        break;
+      case 'list':
+        await listCommand();
+        break;
+      case 'sync':
+        await syncCommand(flags);
+        break;
+      case 'hook':
+        await runHook(args[0]);
+        break;
+      case 'help':
+        console.log(HELP);
+        break;
+      case 'version':
+        console.log(VERSION);
+        break;
+      default:
+        console.log(HELP);
+        process.exit(1);
+    }
+  } catch (error) {
+    console.error('Error:', error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/lib/claude-storage.ts
+++ b/src/lib/claude-storage.ts
@@ -1,0 +1,118 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { ClaudeSession } from './types.js';
+
+/**
+ * Convert cwd path to Claude's project directory naming convention
+ * /Users/jansmrcka/git/project → -Users-jansmrcka-git-project
+ */
+export function cwdToProjectDir(cwd: string): string {
+  return cwd.replace(/\//g, '-');
+}
+
+/**
+ * Get path to Claude's project sessions directory
+ */
+export function getProjectSessionsPath(cwd: string): string {
+  const projectDir = cwdToProjectDir(cwd);
+  return path.join(os.homedir(), '.claude', 'projects', projectDir);
+}
+
+/**
+ * Get path to Claude's plans directory
+ */
+export function getPlansPath(): string {
+  return path.join(os.homedir(), '.claude', 'plans');
+}
+
+/**
+ * Find all sessions for a specific branch
+ */
+export async function findSessionsForBranch(
+  cwd: string,
+  branch: string
+): Promise<ClaudeSession[]> {
+  const sessionsPath = getProjectSessionsPath(cwd);
+  const sessions: ClaudeSession[] = [];
+
+  try {
+    const files = await fs.readdir(sessionsPath);
+    const jsonFiles = files.filter(f => f.endsWith('.json') && !f.startsWith('agent-'));
+
+    for (const file of jsonFiles) {
+      try {
+        const content = await fs.readFile(path.join(sessionsPath, file), 'utf-8');
+        const data = JSON.parse(content) as Partial<ClaudeSession>;
+
+        if (data.gitBranch === branch && data.slug) {
+          sessions.push(data as ClaudeSession);
+        }
+      } catch {
+        // Skip invalid files
+      }
+    }
+  } catch {
+    // Directory doesn't exist
+  }
+
+  // Sort by timestamp, newest first
+  return sessions.sort((a, b) =>
+    new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+}
+
+/**
+ * Find the latest plan slug for a branch
+ */
+export async function findLatestPlanForBranch(
+  cwd: string,
+  branch: string
+): Promise<string | null> {
+  const sessions = await findSessionsForBranch(cwd, branch);
+  return sessions[0]?.slug || null;
+}
+
+/**
+ * Load plan content from Claude's plans directory
+ */
+export async function loadPlanContent(slug: string): Promise<string | null> {
+  const planPath = path.join(getPlansPath(), `${slug}.md`);
+  try {
+    return await fs.readFile(planPath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get all sessions for a project
+ */
+export async function getAllProjectSessions(cwd: string): Promise<ClaudeSession[]> {
+  const sessionsPath = getProjectSessionsPath(cwd);
+  const sessions: ClaudeSession[] = [];
+
+  try {
+    const files = await fs.readdir(sessionsPath);
+    const jsonFiles = files.filter(f => f.endsWith('.json') && !f.startsWith('agent-'));
+
+    for (const file of jsonFiles) {
+      try {
+        const content = await fs.readFile(path.join(sessionsPath, file), 'utf-8');
+        const data = JSON.parse(content) as Partial<ClaudeSession>;
+
+        if (data.slug && data.gitBranch) {
+          sessions.push(data as ClaudeSession);
+        }
+      } catch {
+        // Skip invalid files
+      }
+    }
+  } catch {
+    // Directory doesn't exist
+  }
+
+  return sessions.sort((a, b) =>
+    new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+}

--- a/src/lib/git-utils.ts
+++ b/src/lib/git-utils.ts
@@ -1,0 +1,50 @@
+import { execSync } from 'node:child_process';
+
+export async function getCurrentBranch(cwd: string): Promise<string> {
+  const result = execSync('git rev-parse --abbrev-ref HEAD', {
+    cwd,
+    encoding: 'utf-8',
+  });
+  return result.trim();
+}
+
+export async function getRepoRoot(cwd: string): Promise<string> {
+  const result = execSync('git rev-parse --show-toplevel', {
+    cwd,
+    encoding: 'utf-8',
+  });
+  return result.trim();
+}
+
+export async function isGitRepo(cwd: string): Promise<boolean> {
+  try {
+    execSync('git rev-parse --git-dir', { cwd, encoding: 'utf-8' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getRecentCommits(cwd: string, count = 10): Promise<string[]> {
+  try {
+    const result = execSync(`git log --format=%H -n ${count}`, {
+      cwd,
+      encoding: 'utf-8',
+    });
+    return result.trim().split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+export async function getLatestCommit(cwd: string): Promise<string | null> {
+  try {
+    const result = execSync('git rev-parse HEAD', {
+      cwd,
+      encoding: 'utf-8',
+    });
+    return result.trim();
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/plan-store.ts
+++ b/src/lib/plan-store.ts
@@ -1,0 +1,177 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type { PlanMetadata, TrackedPlan } from './types.js';
+
+/**
+ * Sanitize branch name for use as filename
+ * feature/auth → feature-auth
+ */
+function sanitizeBranchName(branch: string): string {
+  return branch.replace(/\//g, '-');
+}
+
+/**
+ * Get path to plan file in repo
+ */
+export function getPlanPath(repoRoot: string, branch: string): string {
+  const filename = `${sanitizeBranchName(branch)}.md`;
+  return path.join(repoRoot, '.claude', 'plans', filename);
+}
+
+/**
+ * Parse frontmatter from plan content
+ */
+function parseFrontmatter(content: string): { metadata: PlanMetadata | null; content: string } {
+  const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
+  const match = content.match(frontmatterRegex);
+
+  if (!match) {
+    return { metadata: null, content };
+  }
+
+  const [, frontmatterStr, bodyContent] = match;
+
+  try {
+    // Simple YAML parsing for our specific format
+    const metadata: Partial<PlanMetadata> = {};
+    const lines = frontmatterStr.split('\n');
+    let inCommits = false;
+    const commits: string[] = [];
+
+    for (const line of lines) {
+      if (line.startsWith('branch:')) {
+        metadata.branch = line.slice(7).trim();
+      } else if (line.startsWith('source:')) {
+        metadata.source = line.slice(7).trim();
+      } else if (line.startsWith('last_updated:')) {
+        metadata.last_updated = line.slice(13).trim();
+      } else if (line.startsWith('commits:')) {
+        inCommits = true;
+      } else if (inCommits && line.trim().startsWith('-')) {
+        commits.push(line.trim().slice(1).trim());
+      }
+    }
+
+    metadata.commits = commits;
+
+    return {
+      metadata: metadata as PlanMetadata,
+      content: bodyContent.trim(),
+    };
+  } catch {
+    return { metadata: null, content };
+  }
+}
+
+/**
+ * Generate frontmatter string
+ */
+function generateFrontmatter(metadata: PlanMetadata): string {
+  const lines = [
+    '---',
+    `branch: ${metadata.branch}`,
+    `source: ${metadata.source}`,
+    `last_updated: ${metadata.last_updated}`,
+    'commits:',
+    ...metadata.commits.map(c => `  - ${c}`),
+    '---',
+  ];
+  return lines.join('\n');
+}
+
+/**
+ * Save plan to repo
+ */
+export async function savePlan(
+  repoRoot: string,
+  branch: string,
+  content: string,
+  metadata: PlanMetadata
+): Promise<void> {
+  const planPath = getPlanPath(repoRoot, branch);
+  const planDir = path.dirname(planPath);
+
+  await fs.mkdir(planDir, { recursive: true });
+
+  const fullContent = `${generateFrontmatter(metadata)}\n\n${content}`;
+  await fs.writeFile(planPath, fullContent);
+}
+
+/**
+ * Load plan from repo
+ */
+export async function loadPlan(
+  repoRoot: string,
+  branch: string
+): Promise<TrackedPlan | null> {
+  const planPath = getPlanPath(repoRoot, branch);
+
+  try {
+    const content = await fs.readFile(planPath, 'utf-8');
+    const { metadata, content: planContent } = parseFrontmatter(content);
+
+    if (!metadata) {
+      return null;
+    }
+
+    return {
+      metadata,
+      content: planContent,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List all tracked plans in repo
+ */
+export async function listTrackedPlans(repoRoot: string): Promise<TrackedPlan[]> {
+  const plansDir = path.join(repoRoot, '.claude', 'plans');
+  const plans: TrackedPlan[] = [];
+
+  try {
+    const files = await fs.readdir(plansDir);
+    const mdFiles = files.filter(f => f.endsWith('.md'));
+
+    for (const file of mdFiles) {
+      try {
+        const content = await fs.readFile(path.join(plansDir, file), 'utf-8');
+        const { metadata, content: planContent } = parseFrontmatter(content);
+
+        if (metadata) {
+          plans.push({ metadata, content: planContent });
+        }
+      } catch {
+        // Skip invalid files
+      }
+    }
+  } catch {
+    // Directory doesn't exist
+  }
+
+  return plans.sort((a, b) =>
+    new Date(b.metadata.last_updated).getTime() - new Date(a.metadata.last_updated).getTime()
+  );
+}
+
+/**
+ * Add commit to plan
+ */
+export async function addCommitToPlan(
+  repoRoot: string,
+  branch: string,
+  commitHash: string
+): Promise<void> {
+  const existing = await loadPlan(repoRoot, branch);
+
+  if (!existing) {
+    return;
+  }
+
+  if (!existing.metadata.commits.includes(commitHash)) {
+    existing.metadata.commits.push(commitHash);
+    existing.metadata.last_updated = new Date().toISOString();
+    await savePlan(repoRoot, branch, existing.content, existing.metadata);
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Claude Code Hook Input/Output Types
+ */
+
+// Base hook input that all hooks receive
+export interface HookInputBase {
+  session_id: string;
+  transcript_path: string;
+  cwd: string;
+  permission_mode: 'default' | 'plan' | 'acceptEdits' | 'dontAsk' | 'bypassPermissions';
+  hook_event_name: string;
+}
+
+// SessionStart hook input
+export interface SessionStartInput extends HookInputBase {
+  hook_event_name: 'SessionStart';
+  source: 'startup' | 'resume' | 'clear' | 'compact';
+}
+
+// SessionEnd hook input
+export interface SessionEndInput extends HookInputBase {
+  hook_event_name: 'SessionEnd';
+  reason: 'clear' | 'logout' | 'prompt_input_exit' | 'other';
+}
+
+// PostToolUse hook input
+export interface PostToolUseInput extends HookInputBase {
+  hook_event_name: 'PostToolUse';
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  tool_response: Record<string, unknown>;
+  tool_use_id: string;
+}
+
+// Union type for all hook inputs
+export type HookInput = SessionStartInput | SessionEndInput | PostToolUseInput;
+
+// Hook output structure
+export interface HookOutput {
+  continue?: boolean;
+  stopReason?: string;
+  suppressOutput?: boolean;
+  systemMessage?: string;
+  hookSpecificOutput?: {
+    hookEventName: string;
+    additionalContext?: string;
+    permissionDecision?: 'allow' | 'deny' | 'ask';
+    permissionDecisionReason?: string;
+  };
+}
+
+/**
+ * Claude's Internal Storage Types
+ */
+
+// Session JSON structure from ~/.claude/projects/{project}/{uuid}.json
+export interface ClaudeSession {
+  slug: string;           // Links to ~/.claude/plans/{slug}.md
+  gitBranch: string;      // e.g., "master", "feature/auth"
+  sessionId: string;      // UUID
+  cwd: string;            // Full project path
+  timestamp: string;      // ISO date string
+}
+
+/**
+ * Plan Tracking Types
+ */
+
+// Metadata stored in plan frontmatter
+export interface PlanMetadata {
+  branch: string;
+  source: string;         // Original slug filename
+  last_updated: string;   // ISO date string
+  commits: string[];      // Commit hashes
+}
+
+// Full tracked plan with content
+export interface TrackedPlan {
+  metadata: PlanMetadata;
+  content: string;
+}
+
+/**
+ * CLI Types
+ */
+
+export type Command = 'init' | 'status' | 'list' | 'sync' | 'hook' | 'help' | 'version';
+
+export interface CLIArgs {
+  command: Command;
+  args: string[];
+  flags: Record<string, string | boolean>;
+}
+
+/**
+ * Configuration Types
+ */
+
+export interface HookConfig {
+  type: 'command';
+  command: string;
+  timeout?: number;
+}
+
+export interface HookMatcher {
+  matcher?: string;
+  hooks: HookConfig[];
+}
+
+export interface ClaudeSettings {
+  hooks?: {
+    SessionStart?: HookMatcher[];
+    SessionEnd?: HookMatcher[];
+    PreToolUse?: HookMatcher[];
+    PostToolUse?: HookMatcher[];
+    [key: string]: HookMatcher[] | undefined;
+  };
+  [key: string]: unknown;
+}

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -1,0 +1,40 @@
+import type { CLIArgs, Command } from '../lib/types.js';
+
+const VALID_COMMANDS: Command[] = ['init', 'status', 'list', 'sync', 'hook', 'help', 'version'];
+
+export function parseArgs(argv: string[]): CLIArgs {
+  const flags: Record<string, string | boolean> = {};
+  const positional: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const nextArg = argv[i + 1];
+
+      if (nextArg && !nextArg.startsWith('-')) {
+        flags[key] = nextArg;
+        i++;
+      } else {
+        flags[key] = true;
+      }
+    } else if (arg.startsWith('-')) {
+      const key = arg.slice(1);
+      flags[key] = true;
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  const commandStr = positional[0] || 'help';
+  const command: Command = VALID_COMMANDS.includes(commandStr as Command)
+    ? (commandStr as Command)
+    : 'help';
+
+  return {
+    command,
+    args: positional.slice(1),
+    flags,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Complete implementation of the claude-plan-tracker CLI tool that integrates with Claude Code via hooks.

### Features implemented:
- **SessionStart hook** - Automatically loads previous plan context when starting a Claude Code session
- **SessionEnd hook** - Persists current plan to `.claude/plans/{branch}.md` when session ends
- **PostToolUse hook** - Tracks git commits made during the session

### CLI Commands:
- `init` - Setup hooks in `.claude/settings.json`
- `status` - Show plan status for current branch
- `list` - List all tracked branches and plans
- `sync` - Manually sync current plan to repo

### Technical details:
- Zero runtime dependencies (only dev deps for TypeScript)
- Reads Claude's internal storage (`~/.claude/projects/`, `~/.claude/plans/`)
- Plans saved with YAML frontmatter containing metadata (branch, source, commits)

## Test plan

- [x] Build compiles without errors
- [x] `claude-plan-tracker --help` shows usage
- [x] `claude-plan-tracker init` creates hooks configuration
- [x] `claude-plan-tracker status` shows current branch info
- [x] `claude-plan-tracker list` lists tracked plans
- [ ] End-to-end test with actual Claude Code session

Closes #1